### PR TITLE
[fix] Initalize cookie data with an empty string

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ var has = Object.prototype.hasOwnProperty
 function update() {
   if (!koekje.supported) return;
 
-  var data = cookie.get('koekje')
+  var data = cookie.get('koekje') || ''
     , length = 0
     , key;
 


### PR DESCRIPTION
This is a simple fix on `update` function to make this module work as a fallback of your awesome sessionstorage module.

The first `cookie.get('koekje')` call returns `undefined` and you're calling `charAt` on it, rasing an exception. I've simply initialized the `data` variabile to an empty string if the `cookie.get` call returns a falsy value. This way everything works fine both here and on `sessionstorage` module.
